### PR TITLE
Added support for non AlsaAudio Systems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@ You will need a Spotify Premium account and a Spotify username (if you signed up
 
 You will need libspotify, libffi-dev and libasound2-dev installed.
 
-Use your distribution's package manager for libffi-dev and libasound2-dev (f.x. :code:`apt-get install libffi-dev libasound2-dev`).
+You will either need to install :code:`pyaudio` or :code:`alsaaudio` by (running :code:`pip install pyaudio` and :code:`pip install pyalsaaudio`).
+
+Use your distribution's package manager for libffi-dev (f.x. :code:`apt-get install libffi-dev`).
 
 To install libspotify, see `Pyspotify installation <https://pyspotify.mopidy.com/en/latest/installation/#install-from-source>`_. (It's also available in the `AUR <https://aur.archlinux.org/packages/libspotify/>`_).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click>=6.2
-pyalsaaudio>=0.8.2
 pyspotify>=2.0.5
 appdirs>=1.4.0
 requests>=2.9.1


### PR DESCRIPTION
This enables PortAudio to be used for audio sinks.
Please note that there is no checking on install time if pyalsaaudio or
pyaudio is installed, since pip install can not differntiate between
operating systems.

This is for #142 
