### PR TITLE
Added basic auto-updating functionality

### DIFF
--- a/spoppy/__init__.py
+++ b/spoppy/__init__.py
@@ -59,6 +59,12 @@ def check_for_updates(lock):
                     click.echo(
                         "You will have to manually update spoppy")
 
+                    # Pause execution so the user sees the error
+                    try:
+                        raw_input()
+                    except NameError:
+                        input()
+
 if click:
     @click.command()
     @click.argument('username', required=False)

--- a/spoppy/__init__.py
+++ b/spoppy/__init__.py
@@ -1,4 +1,6 @@
 import logging
+import requests
+import subprocess
 
 try:
     import click
@@ -13,6 +15,50 @@ def get_version():
     return '1.7.5'
 
 
+def check_for_updates(lock):
+    info = requests.get(
+        "https://pypi.python.org/pypi/spoppy/json").json()["info"]
+
+    pypi_version = info["version"].split('.')
+
+    version = get_version().split('.')
+
+    for sub in version:
+        if sub < pypi_version[version.index(sub)]:
+            click.echo("\033[1m\033[94mA new version of spoppy is "
+                       "available!\033[0m")
+            click.echo("\033[1m\033[96m Installed: {} \033[92m"
+                       "PyPi: {}\033[0m".format('.'.join(version),
+                                                '.'.join(pypi_version)))
+            click.echo("\033[94m You can install it yourself or "
+                       "automatically download it. Automatically "
+                       "install it?\033[0m")
+            try:
+                response = raw_input(
+                    '[Y(Automatically) / n(Manually)] ').lower()
+            except NameError:
+                response = input(
+                    '[Y(Automatically) / n(Manually)] ').lower()
+
+            # Only do anything if they say yes
+            if response == "y":
+                try:
+                    subprocess.check_call(
+                        ["sudo", "pip", "install", "spoppy", "--upgrade"])
+                    click.echo(
+                        "\033[1m\033[92mspoppy updated sucessfully!\033[0m")
+
+                    click.echo("Please restart spoppy!")
+                    lock.release()
+                    raise SystemExit
+
+                except subprocess.CalledProcessError:
+                    # Pip failed to automatically update
+                    click.echo(
+                        "\033[1m\033[91mAutomatic updating failed!\033[0m")
+                    click.echo(
+                        "You will have to manually update spoppy")
+
 if click:
     @click.command()
     @click.argument('username', required=False)
@@ -26,6 +72,10 @@ if click:
 
         lock = LockFile('/tmp/spoppy')
         check_internet_connection()
+
+        # Check for updates
+        check_for_updates(lock)
+
         try:
             try:
                 # Try for 1s to acquire the lock


### PR DESCRIPTION
This code, executed on each startup, checks with the PyPi API to see if there is a newer version of spoppy available. It then asks the user if spoppy should be automatically updated (via `pip`) and if so, upgrades spoppy. If `pip` fails for some reason, spoppy will continue to launch after letting the user know.

I had issues getting spoppy to install on my system, but I tested my code externally and it works as intended.

It definitely can be improved, but this should provide a nice basis to work off of!

Hopefully this helps fix #129.
